### PR TITLE
devkitARM r46 fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+BootLoader/build
+BootLoader/load.bin
+arm7/build
+arm9/build/
+arm9/data/
+arm9/source/version.h
+*.nds
+*.elf

--- a/BootLoader/Makefile
+++ b/BootLoader/Makefile
@@ -21,17 +21,17 @@ SPECS		:=  specs
 #---------------------------------------------------------------------------------
 # options for code generation
 #---------------------------------------------------------------------------------
-ARCH	:=	-mthumb-interwork
+ARCH	:=	-mthumb-interwork -march=armv4t -mtune=arm7tdmi
 
 CFLAGS	:=	-g -Wall -O2\
-			-mcpu=arm7tdmi -mtune=arm7tdmi -fomit-frame-pointer\
+			-fomit-frame-pointer\
 			-ffast-math \
 			-Wall -Wextra -Werror \
 			$(ARCH)
 
 CFLAGS	+=	$(INCLUDE) -DARM7
 
-ASFLAGS	:=	-g $(ARCH)
+ASFLAGS	:=	-g $(ARCH) $(INCLUDE)
 LDFLAGS	:=	-nostartfiles -T$(CURDIR)/../load.ld -g $(ARCH) -Wl,-Map,$(TARGET).map
 
 LIBS	:= -lnds7

--- a/BootLoader/source/cheat_engine.s
+++ b/BootLoader/source/cheat_engine.s
@@ -14,6 +14,7 @@
 @   You should have received a copy of the GNU General Public License
 @   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+#include <nds/asminc.h>
 .arm
 
 .global cheat_engine_start
@@ -31,7 +32,7 @@ intr_orig_return_offset:
 	
 @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 
-cheat_engine_start:
+BEGIN_ASM_FUNC cheat_engine_start
 @ Hook the return address, then go back to the original function
 	stmdb	sp!, {lr}
 	adr 	lr, code_handler_start

--- a/BootLoader/source/clear_cache.arm9.s
+++ b/BootLoader/source/clear_cache.arm9.s
@@ -17,10 +17,11 @@
 @ Clears ICache and Dcache, and resets the protection units
 @ Originally written by Darkain, modified by Chishm
 
-.arm
-.global arm9_clearCache
+#include <nds/asminc.h>
 
-arm9_clearCache:
+.arm
+
+BEGIN_ASM_FUNC arm9_clearCache
 	@ Clean and flush cache
 	mov r1, #0                   
 	outer_loop:                  

--- a/BootLoader/source/clear_mem.s
+++ b/BootLoader/source/clear_mem.s
@@ -17,10 +17,12 @@
 @ void arm7_clearmem (void* loc, size_t len);
 @ Clears memory using an stmia loop
 
-.arm
-.global arm7_clearmem
+#include <nds/asminc.h>
 
-arm7_clearmem:
+.arm
+
+
+BEGIN_ASM_FUNC arm7_clearmem
 	add    r1, r0, r1
 	stmfd  sp!, {r4-r9}
 	mov    r2, #0

--- a/BootLoader/source/clear_mem.s
+++ b/BootLoader/source/clear_mem.s
@@ -35,7 +35,8 @@ BEGIN_ASM_FUNC arm7_clearmem
 	mov    r9, #0
 
 clearmem_loop:
-	stmia  r0!, {r2-r9}	cmp    r0, r1
+	stmia  r0!, {r2-r9}
+	cmp    r0, r1
 	blt    clearmem_loop
 
 	ldmfd  sp!, {r4-r9}

--- a/BootLoader/source/read_bios.s
+++ b/BootLoader/source/read_bios.s
@@ -1,3 +1,5 @@
+#include <nds/asminc.h>
+
 @This code comes from a post by CaitSith2 at gbadev.org - THANKS!!
 @
 @Code to dump the complete Nintendo DS ARM7 bios, including the
@@ -9,12 +11,12 @@
 @Additionally, if the PC is outside the 0x0000 - 0x1204 range, that range of the bios
 @is completely locked out from reading.
 
-.global readBios
+
 @ void readBios (u8* dest, u32 src, u32 size)
 
-    .align
-readBios:
     .arm
+
+BEGIN_ASM_FUNC readBios
     adr r3,bios_dump+1
     bx r3
     .thumb

--- a/Makefile
+++ b/Makefile
@@ -15,12 +15,20 @@ export VERSION_MINOR	:= 93
 export VERSTRING	:=	$(VERSION_MAJOR).$(VERSION_MINOR)
 
 
-.PHONY: arm7/$(TARGET).elf arm9/$(TARGET).elf
+.PHONY: checkarm7 checkarm9
 
 #---------------------------------------------------------------------------------
 # main targets
 #---------------------------------------------------------------------------------
-all: $(TARGET).nds
+all: checkarm7 checkarm9 $(TARGET).nds
+
+#---------------------------------------------------------------------------------
+checkarm7:
+	$(MAKE) -C arm7
+
+#---------------------------------------------------------------------------------
+checkarm9:
+	$(MAKE) -C arm9
 
 $(TARGET).nds	:	arm7/$(TARGET).elf arm9/$(TARGET).elf
 	ndstool	-c $(TARGET).nds -7 arm7/$(TARGET).elf -9 arm9/$(TARGET).elf \

--- a/arm7/Makefile
+++ b/arm7/Makefile
@@ -22,10 +22,10 @@ DATA		:=
 #---------------------------------------------------------------------------------
 # options for code generation
 #---------------------------------------------------------------------------------
-ARCH	:=	-mthumb-interwork
+ARCH	:=	-mthumb-interwork -march=armv4t -mtune=arm7tdmi
 
 CFLAGS	:=	-g -Wall -O2\
-		-mcpu=arm7tdmi -mtune=arm7tdmi -fomit-frame-pointer\
+		-fomit-frame-pointer\
 		-ffast-math \
 		-Wall -Wextra -Werror \
 		$(ARCH)
@@ -34,7 +34,7 @@ CFLAGS	+=	$(INCLUDE) -DARM7
 CXXFLAGS	:=	$(CFLAGS) -fno-rtti -fno-exceptions -fno-rtti
 
 
-ASFLAGS	:=	-g $(ARCH)
+ASFLAGS	:=	-g $(ARCH) $(INCLUDE)
 LDFLAGS	=	-specs=ds_arm7.specs -g $(ARCH) -Wl,-Map,$(notdir $*).map
 
 LIBS	:=	-lnds7

--- a/arm9/Makefile
+++ b/arm9/Makefile
@@ -23,10 +23,10 @@ DATA		:=	data
 #---------------------------------------------------------------------------------
 # options for code generation
 #---------------------------------------------------------------------------------
-ARCH	:=	-mthumb -mthumb-interwork
+ARCH	:=	-march=armv5te -mtune=arm946e-s -mthumb -mthumb-interwork
 
 CFLAGS	:=	-g -Wall -O2\
- 			-march=armv5te -mtune=arm946e-s -fomit-frame-pointer\
+			-fomit-frame-pointer\
 			-ffast-math \
 			-Wall -Wextra -Werror \
 			$(ARCH)
@@ -34,7 +34,7 @@ CFLAGS	:=	-g -Wall -O2\
 CFLAGS	+=	$(INCLUDE) -DARM9
 CXXFLAGS	:=	$(CFLAGS)
 
-ASFLAGS	:=	-g $(ARCH) -march=armv5te -mtune=arm946e-s
+ASFLAGS	:=	-g $(ARCH) $(INCLUDE)
 
 LDFLAGS	=	-specs=ds_arm9.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)
 


### PR DESCRIPTION
Mainly a bit of housekeeping to tidy things up a little.

Latest binutils likes to mark assembled object files with odd architectures if you don't explicitly specify. The linker then  decides to use blx for interworking calls because one object file is marked as an arch that supports it.

Marking assembly functions properly doesn't seem to be strictly necessary in this codebase but it's worth doing to avoid potential problems in the future.

All tested and working on DS hardware. Some more updates for DSi mode later.