### PR TITLE
showCheatFolder: fix message display when menuLevel.selected == -1

### DIFF
--- a/arm9/source/ui.cpp
+++ b/arm9/source/ui.cpp
@@ -653,10 +653,15 @@ void UserInterface::cheatMenu (CheatFolder* gameCodes, CheatFolder* top)
 		setCursorPosition ((MENU_FIRST_ROW + menuLevel.selected - menuLevel.top) * TOUCH_GRID_SIZE);
 		setScrollbarPosition (CHEAT_MENU_TOP + menuLevel.selected, (int)contents.size()-1);
 		showMessage (TEXT_TITLE, "%s", gameCodes->getName());
-		if (contents[menuLevel.selected]->note.empty()) {
-			showMessage (TEXT_INFO, "%s", contents[menuLevel.selected]->getName());
+
+		if (menuLevel.selected != CHEAT_MENU_FOLDER_UP) {
+			if (contents[menuLevel.selected]->note.empty()) {
+				showMessage (TEXT_INFO, "%s", contents[menuLevel.selected]->getName());
+			} else {
+				showMessage (TEXT_INFO, "%s\n\n%s", contents[menuLevel.selected]->getName(), contents[menuLevel.selected]->getNote());
+			}
 		} else {
-			showMessage (TEXT_INFO, "%s\n\n%s", contents[menuLevel.selected]->getName(), contents[menuLevel.selected]->getNote());
+			showMessage (TEXT_INFO, "Parent Directory");
 		}
 	}
 


### PR DESCRIPTION
The key to this issue is that menuLevel.selected covers the range of
possible entry indexes, but also  includes the extra value of
CHEAT_MENU_FOLDER_UP, which is -1. When that entry is selected,
previously the note/name were still displayed by checking
contents[menuLevel.selected], which indexes contents with -1 and ends up
reading a bogus value (Which crashes NitroHax depending on the loaded
XML and likely other factors).

The simple fix is to check the value is equal to CHEAT_MENU_FOLDER_UP
before attempting to display the name, and if it is, display a hardcoded
string instead.

Note: From my testing this fixes the issue I was having with my cheats.xml file where it would freeze when selecting `".."`, and also fixes @murrty's file from #10 (I can browse his whole file just fine, before it would crash like mine).

Also note: I didn't heavily test this, but I don't believe `UserInterface::fileBrowser` is affected by this bug, because I don't believe `menuLevel.selected` ever goes below 0 in that case.

And a third note: I haven't actually verified any cheats actually work, though I didn't touch any of that code. I was intending to use Pokemon White 2, but it sounds like that doesn't actually work without some other more fundamental changes to the BootLoader, which looks well beyond by current capability...