### PR TITLE
Fix compilation with devkitARM r56-3

### DIFF
--- a/BootLoader/Makefile
+++ b/BootLoader/Makefile
@@ -27,7 +27,6 @@ CFLAGS	:=	-g -Wall -O2\
 			-fomit-frame-pointer\
 			-ffast-math \
 			-Wall -Wextra -Werror \
-			-Wno-address-of-packed-member \
 			$(ARCH)
 
 CFLAGS	+=	$(INCLUDE) -DARM7

--- a/BootLoader/source/common.h
+++ b/BootLoader/source/common.h
@@ -26,23 +26,34 @@
 #define resetCpu() \
 		__asm volatile("swi 0x000000")
 
-enum {	ERR_NONE=0x00, ERR_STS_CLR_MEM=0x01, ERR_STS_LOAD_BIN=0x02, ERR_STS_HOOK_BIN=0x03, ERR_STS_START=0x04,
-		// initCard error codes:
-		ERR_LOAD_NORM=0x11, ERR_LOAD_OTHR=0x12, ERR_SEC_NORM=0x13, ERR_SEC_OTHR=0x14, ERR_LOGO_CRC=0x15, ERR_HEAD_CRC=0x16,
-		// hookARM7Binary error codes:
-		ERR_NOCHEAT=0x21, ERR_HOOK=0x22,
-	} ERROR_CODES;
+enum ERROR_CODES {
+	ERR_NONE = 0x00,
+	ERR_STS_CLR_MEM = 0x01,
+	ERR_STS_LOAD_BIN = 0x02,
+	ERR_STS_HOOK_BIN = 0x03,
+	ERR_STS_START = 0x04,
+	// initCard error codes:
+	ERR_LOAD_NORM = 0x11,
+	ERR_LOAD_OTHR = 0x12,
+	ERR_SEC_NORM = 0x13,
+	ERR_SEC_OTHR = 0x14,
+	ERR_LOGO_CRC = 0x15,
+	ERR_HEAD_CRC = 0x16,
+	// hookARM7Binary error codes:
+	ERR_NOCHEAT = 0x21,
+	ERR_HOOK = 0x22,
+};
 
 // Values fixed so they can be shared with ASM code
-enum {
+enum ARM9_STATE {
 	ARM9_BOOT = 0,
 	ARM9_START = 1,
 	ARM9_RESET = 2,
 	ARM9_READY = 3,
 	ARM9_MEMCLR = 4
-} ARM9_STATE;
+};
 
-enum {
+enum ARM7_STATE {
 	ARM7_BOOT = 0,
 	ARM7_START = 1,
 	ARM7_RESET = 2,
@@ -52,7 +63,7 @@ enum {
 	ARM7_HOOKBIN = 6,
 	ARM7_BOOTBIN = 7,
 	ARM7_ERR = 8
-} ARM7_STATE;
+};
 
 extern volatile u32 arm9_errorCode;
 

--- a/BootLoader/source/main.arm9.c
+++ b/BootLoader/source/main.arm9.c
@@ -62,6 +62,7 @@ Written by Chishm
 static void arm9_errorOutput (u32 code) {
 	int i, j, k;
 	u16 colour;
+	vu16 *const vram_a = (vu16*)VRAM_A;
 
 	REG_POWERCNT = (u16)(POWER_LCD | POWER_2D_A);
 	REG_DISPCNT = MODE_FB0;
@@ -69,7 +70,7 @@ static void arm9_errorOutput (u32 code) {
 
 	// Clear display
 	for (i = 0; i < 256*192; i++) {
-		VRAM_A[i] = 0x0000;
+		vram_a[i] = 0x0000;
 	}
 
 	// Draw boxes of colour, signifying error codes
@@ -88,7 +89,7 @@ static void arm9_errorOutput (u32 code) {
 			}
 			for (j = 71; j < 87; j++) { 				// Row
 				for (k = 32*i+8; k < 32*i+24; k++) {	// Column
-					VRAM_A[j*256+k] = colour;
+					vram_a[j*256+k] = colour;
 				}
 			}
 		}
@@ -107,7 +108,7 @@ static void arm9_errorOutput (u32 code) {
 		}
 		for (j = 103; j < 119; j++) { 				// Row
 			for (k = 32*i+8; k < 32*i+24; k++) {	// Column
-				VRAM_A[j*256+k] = colour;
+				vram_a[j*256+k] = colour;
 			}
 		}
 	}

--- a/BootLoader/source/read_card.c
+++ b/BootLoader/source/read_card.c
@@ -18,6 +18,7 @@
 
 #include "read_card.h"
 
+#include <assert.h>
 #include <nds.h>
 #include <nds/arm9/cache.h>
 #include <nds/dma.h>
@@ -146,6 +147,9 @@ int cardInit (tNDSHeader* ndsHeader, u32* chipID)
 	cardParamCommand (CARD_CMD_DUMMY, 0,
 		CARD_ACTIVATE | CARD_nRESET | CARD_CLK_SLOW | CARD_BLK_SIZE(1) | CARD_DELAY1(0x1FFF) | CARD_DELAY2(0x3F),
 		NULL, 0);
+
+	// Verify that the ndsHeader is packed correctly, now that it's no longer __packed__
+	static_assert(sizeof(tNDSHeader) == 0x160, "tNDSHeader not packed properly");
 
 	// Read the header
 	cardParamCommand (CARD_CMD_HEADER_READ, 0,

--- a/arm9/source/cheat_engine.c
+++ b/arm9/source/cheat_engine.c
@@ -21,20 +21,30 @@
 
 #include "load_bin.h"
 #include "cheat_engine.h"
-#define LCDC_BANK_C (u16*)0x06840000
+#define LCDC_BANK_C (vu16*)0x06840000
 
 #define CHEAT_DATA_LOCATION ((u32*)0x06850000)
 #define CHEAT_CODE_END	0xCF000000
 
-void vramcpy (void* dst, const void* src, int len)
+static void vramset (volatile void* dst, u16 val, int len)
 {
-	u16* dst16 = (u16*)dst;
-	u16* src16 = (u16*)src;
-	
-	for ( ; len > 0; len -= 2) {
-		*dst16++ = *src16++;
+	vu32* dst32 = (vu32*)dst;
+	u32 val32 = val | (val << 16);
+
+	for ( ; len > 0; len -= 4) {
+		*dst32++ = val32;
 	}
-}	
+}
+
+static void vramcpy (volatile void* dst, const void* src, int len)
+{
+	vu32* dst32 = (vu32*)dst;
+	const u32* src32 = (u32*)src;
+
+	for ( ; len > 0; len -= 4) {
+		*dst32++ = *src32++;
+	}
+}
 
 void runCheatEngine (void* cheats, int cheatLength)
 {
@@ -44,7 +54,7 @@ void runCheatEngine (void* cheats, int cheatLength)
 	// Direct CPU access to VRAM bank C
 	VRAM_C_CR = VRAM_ENABLE | VRAM_C_LCD;
 	// Clear VRAM
-	memset (LCDC_BANK_C, 0x00, 128 * 1024);
+	vramset (LCDC_BANK_C, 0x0000, 128 * 1024);
 	// Load the loader/patcher into the correct address
 	vramcpy (LCDC_BANK_C, load_bin, load_bin_size);
 	// Put the codes 64KiB after the start of the loader

--- a/arm9/source/consoletext.cpp
+++ b/arm9/source/consoletext.cpp
@@ -22,16 +22,17 @@
 #define TAB_STOP 4
 #define SCREEN_WIDTH 32
 
-ConsoleText::ConsoleText (int width, int height, CHAR_SIZE tileSize, u16* fontMap, u16 palette)
+
+ConsoleText::ConsoleText (int width, int height, CHAR_SIZE tileSize, vu16 *const fontMap, u16 palette):
+	fontPal(palette << 12),
+	row(0),
+	col(0),
+	width(width),
+	height(height),
+	fontStart(0),
+	fontMap(fontMap),
+	tileSize(tileSize)
 {
-	this->width = width;
-	this->height = height;
-	this->tileSize = tileSize;
-	this->fontStart = 0;
-	this->fontMap = fontMap;
-	this->fontPal = (u16)(palette << 12);
-	this->row = 0;
-	this->col = 0;
 }
 
 void ConsoleText::clearText (void)

--- a/arm9/source/consoletext.h
+++ b/arm9/source/consoletext.h
@@ -23,7 +23,7 @@ class ConsoleText
 public:
 	enum CHAR_SIZE {CHAR_SIZE_8PX, CHAR_SIZE_16PX};
 
-	ConsoleText (int width, int height, CHAR_SIZE tileSize, u16* fontMap, u16 palette);
+	ConsoleText (int width, int height, CHAR_SIZE tileSize, vu16 *const fontMap, u16 palette);
 
 	void setPosition (int x, int y);
 	void clearText (void);
@@ -44,6 +44,6 @@ private:
 	int row, col;
 	int width, height;
 	int fontStart;
-	u16* fontMap;
+	vu16 *const fontMap;
 	CHAR_SIZE tileSize;
 } ;

--- a/arm9/source/ui.cpp
+++ b/arm9/source/ui.cpp
@@ -101,10 +101,10 @@ const char CHEAT_MENU_FOLDER_UP_NAME[] = " [..]";
 
 UserInterface ui;
 
-void vramcpy (void* dest, const void* src, int size)
+static void vramcpy (volatile void* dest, const void* src, int size)
 {
-	u16* destination = (u16*)dest;
-	u16* source = (u16*)src;
+	vu16* destination = (vu16*)dest;
+	const u16* source = (u16*)src;
 	while (size > 0) {
 		*destination++ = *source++;
 		size-=2;
@@ -151,8 +151,9 @@ UserInterface::UserInterface (void)
 	vramcpy ((void*)(CHAR_BASE_BLOCK(4) + TEXTBOX_OFFSET * TILE_SIZE), textboxTiles, textboxTilesLen);
 	textboxMap = (u16*)SCREEN_BASE_BLOCK(2);
 	// Clear tile 0
+	vu16 *const tile_0 = (vu16*) BG_TILE_RAM(4);
 	for (int i = 0; i < TILE_SIZE/2; i++) {
-		((u16*)CHAR_BASE_BLOCK(4))[i] = 0;
+		tile_0[i] = 0;
 	}
 	clearBox();
 
@@ -168,8 +169,8 @@ UserInterface::UserInterface (void)
 	BG_OFFSET_SUB[2].x = -4;
 	BG_OFFSET_SUB[2].y = -4;
 
-	u16* fontMapTop = (u16*)SCREEN_BASE_BLOCK(4);
-	u16* fontMapSub = (u16*)SCREEN_BASE_BLOCK_SUB(4);
+	vu16 *const fontMapTop = (u16*)SCREEN_BASE_BLOCK(4);
+	vu16 *const fontMapSub = (u16*)SCREEN_BASE_BLOCK_SUB(4);
 
 	// Initialise consoles
 	topText = new ConsoleText (CONSOLE_SCREEN_WIDTH, CONSOLE_SCREEN_HEIGHT,
@@ -181,8 +182,8 @@ UserInterface::UserInterface (void)
 	}
 
 	// Set up the GUI BG
-	u16* tileDestSub = (u16*)CHAR_BASE_BLOCK_SUB(4);
-	guiSubMap = (u16*)SCREEN_BASE_BLOCK_SUB(2);
+	vu16 *const tileDestSub = (vu16*)CHAR_BASE_BLOCK_SUB(4);
+	guiSubMap = (vu16*)SCREEN_BASE_BLOCK_SUB(2);
 	BG_OFFSET[1].x = 0;
 	BG_OFFSET[1].y = 0;
 	// Create a double size blank tile
@@ -964,7 +965,8 @@ void UserInterface::demo (void)
 	setScrollbarPosition (menuLength - 1, menuLength - 1);
 	showMessage (TEXT_TITLE, "Mario Kart DS (USA)");
 
-	for (int curItem = 0; curItem < menuLength; curItem++) {		subText->putText (demoMenu[curItem].name, (MENU_FIRST_ROW + curItem) * 2,
+	for (int curItem = 0; curItem < menuLength; curItem++) {
+		subText->putText (demoMenu[curItem].name, (MENU_FIRST_ROW + curItem) * 2,
 			MENU_FIRST_COL, (MENU_FIRST_ROW + curItem) * 2, MENU_LAST_COL, (MENU_FIRST_ROW + curItem) * 2, MENU_FIRST_COL);
 
 		putButtonBg ((BUTTON_BG_OFFSETS)demoMenu[curItem].icon, (MENU_FIRST_ROW + curItem) * 2);

--- a/arm9/source/ui.h
+++ b/arm9/source/ui.h
@@ -82,7 +82,8 @@ private:
 
  	static const int GO_BUTTON_PALETTE = 8;
  	static const int GO_BUTTON_OFFSET = 256;
- 	static const int BLANK_TILE = 0;
+
+	static const int BLANK_TILE = 0;
 
 	static const int NUM_CURSORS = 4;
 
@@ -94,7 +95,7 @@ private:
 	// GUI elements
 	Sprite* scrollbox;
 	Sprite* cursor[NUM_CURSORS];
-	u16* guiSubMap;
+	vu16* guiSubMap;
 	int scrollboxPosition;
 
 	// Menu elements
@@ -120,11 +121,12 @@ private:
 
 	int menuInput(bool enableGoButton);
 
- 	void putGuiTile (int val, int row, int col, int palette, bool doubleSize);
+	void putGuiTile (int val, int row, int col, int palette, bool doubleSize);
 	void clearFolderBackground(void);
- 	void showCursor (bool visible);
- 	void setCursorPosition (int offset);
- 	void putButtonBg (BUTTON_BG_OFFSETS buttonBg, int position);	void showScrollbar (bool visisble);
+	void showCursor (bool visible);
+	void setCursorPosition (int offset);
+	void putButtonBg (BUTTON_BG_OFFSETS buttonBg, int position);
+	void showScrollbar (bool visisble);
 	void setScrollbarPosition (int offset, int listLength);
 	void showGoButton (bool visible, int left, int top);
 } ;


### PR DESCRIPTION
Latest devkitARM has gcc 11.1, which has an advanced optimiser able to detect out-of-bounds array accesses via pointers. This broke accessing hardware addresses using a `u16*`, since the compiler thought it was an array of 0 length. Fixed by using `vu16*` (volatile types) to prevent aggressive optimisation turning for-loop fills/copies into memset/memcpy. 

Fixes #13 .